### PR TITLE
fix(*): add correct files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "luke@screen.cloud",
   "license": "MIT",
   "files": [
-    "/dist"
+    "lib"
   ],
   "devDependencies": {
     "browserify": "^13.3.0",


### PR DESCRIPTION
There is no build script in package.json, so i recon there is no automatic build happening. And all the build scripts are browserify based, so they are pretty much useless for bundling.